### PR TITLE
https://github.com/MachoThemes/modula-lite/issues/108

### DIFF
--- a/assets/css/modula-cpt.css
+++ b/assets/css/modula-cpt.css
@@ -561,7 +561,7 @@ tr label.th-label {
 }
 .modula-uploader-inline-content {
   position: relative;
-  min-height: 300px;
+  min-height: max-content;
   width: 100%;
 }
 .modula-resizer-enabled .modula-uploader-inline-content {


### PR DESCRIPTION
Images no longer shift up when deleting . Tested myself needs testing from others .